### PR TITLE
Add dnf options

### DIFF
--- a/nattd.json
+++ b/nattd.json
@@ -673,7 +673,7 @@
                         "if command -v dnf4 &>/dev/null; then",
                         "  dnf4 config-manager --add-repo https://repository.mullvad.net/rpm/stable/mullvad.repo",
                         "else",
-                        "  dnf config-manager --add-repo https://repository.mullvad.net/rpm/stable/mullvad.repo",
+                        "  dnf config-manager addrepo --from-repofile=https://repository.mullvad.net/rpm/stable/mullvad.repo",
                         "fi",
                         "dnf install -y mullvad-vpn"
                     ],

--- a/nattd.json
+++ b/nattd.json
@@ -281,7 +281,8 @@
                         },
                         "Flatpak": {
                             "command": "flatpak install -y flathub org.mozilla.Thunderbird"
-                    }
+                        }
+                    }    
                 },
                 "install_betterbird": {
                     "name": "Betterbird",

--- a/nattd.json
+++ b/nattd.json
@@ -229,8 +229,23 @@
                 },
                 "install_edge": {
                     "name": "Microsoft Edge",
-                    "command": "flatpak install -y flathub com.microsoft.Edge",
-                    "description": "The web browser from Microsoft."
+                    "description": "The web browser from Microsoft.",
+                    "installation_types": {
+                        "DNF": {
+                            "command": [
+                                "rpm --import https://packages.microsoft.com/keys/microsoft.asc",
+                                "if command -v dnf4 &>/dev/null; then",
+                                "  dnf4 config-manager --add-repo https://packages.microsoft.com/yumrepos/edge",
+                                "else",
+                                "  dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/yumrepos/edge",
+                                "fi",
+                                "dnf install -y microsoft-edge-stable"
+                            ]
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub com.microsoft.Edge"
+                        }
+                    }
                 },
                 "install_librewolf": {
                     "name": "LibreWolf",

--- a/nattd.json
+++ b/nattd.json
@@ -149,8 +149,15 @@
             "apps": {
                 "install_firefox": {
                     "name": "Firefox",
-                    "command": "flatpak install -y flathub org.mozilla.firefox",
-                    "description": "Fast, private & safe web browser."
+                    "description": "Fast, private & safe web browser.",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y firefox"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.mozilla.firefox"
+                        }
+                    }
                 },
                 "install_chrome": {
                     "name": "Google Chrome",

--- a/nattd.json
+++ b/nattd.json
@@ -274,8 +274,14 @@
                 },
                 "install_thunderbird": {
                     "name": "Thunderbird",
-                    "command": "flatpak install -y flathub org.mozilla.Thunderbird",
-                    "description": "The email client from Mozilla."
+                    "description": "The email client from Mozilla.",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y thunderbird"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.mozilla.Thunderbird"
+                    }
                 },
                 "install_betterbird": {
                     "name": "Betterbird",

--- a/nattd.json
+++ b/nattd.json
@@ -161,8 +161,22 @@
                 },
                 "install_chrome": {
                     "name": "Google Chrome",
-                    "command": "flatpak install -y flathub com.google.Chrome",
-                    "description": "The web browser from Google."
+                    "description": "The web browser from Google.",
+                    "installation_types": {
+                        "DNF": {
+                            "command": [
+                                "if command -v dnf4 &>/dev/null; then",
+                                "  dnf4 config-manager --set-enabled google-chrome",
+                                "else",
+                                "  dnf config-manager setopt google-chrome.enabled=1",
+                                "fi",
+                                "dnf install -y google-chrome-stable"
+                            ]
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub com.google.Chrome"
+                        }
+                    }
                 },
                 "install_chromium": {
                     "name": "Chromium",

--- a/nattd.json
+++ b/nattd.json
@@ -249,8 +249,18 @@
                 },
                 "install_librewolf": {
                     "name": "LibreWolf",
-                    "command": "flatpak install -y flathub io.gitlab.librewolf-community",
-                    "description": "A privacy-focused fork of Firefox, emphasizing security and user freedom."
+                    "description": "A privacy-focused fork of Firefox, emphasizing security and user freedom.",
+                    "installation_types": {
+                        "DNF": {
+                            "command": [
+                                "curl -fsSL https://repo.librewolf.net/librewolf.repo | pkexec tee /etc/yum.repos.d/librewolf.repo",
+                                "dnf install -y librewolf"
+                            ]
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub io.gitlab.librewolf-community"
+                        }
+                    }
                 },
                 "install_opera": {
                     "name": "Opera",

--- a/nattd.json
+++ b/nattd.json
@@ -180,8 +180,15 @@
                 },
                 "install_chromium": {
                     "name": "Chromium",
-                    "command": "flatpak install -y flathub org.chromium.Chromium",
-                    "description": "An open-source browser project that aims to build a safer, faster, and more stable way to experience the web."
+                    "description": "An open-source browser project that aims to build a safer, faster, and more stable way to experience the web.",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y chromium"                            
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.chromium.Chromium"
+                        }
+                    }
                 },
                 "install_brave": {
                     "name": "Brave",


### PR DESCRIPTION
**In follow-up to Issue #7, I added DNF options for:**

- Firefox
- Google Chrome
- Chromium
- Microsoft Edge
- LibreWolf
- Thunderbird

Additionally, I updated the add-repo command for **Mullvad-VPN** to use the *dnf5-version* command.

The DNF install options have been tested in a fresh Fedora 41 Workstation VM.