### PR TITLE
Add more dnf-options

### DIFF
--- a/nattd.json
+++ b/nattd.json
@@ -578,6 +578,14 @@
                 },
                 "install_krita": {
                     "name": "Krita",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y krita"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.kde.krita"
+                        }
+                    },
                     "command": "flatpak install -y flathub org.kde.krita",
                     "description": "A full-featured digital art studio."
                 },

--- a/nattd.json
+++ b/nattd.json
@@ -667,7 +667,14 @@
                 },
                 "install_retroarch": {
                     "name": "RetroArch",
-                    "command": "flatpak install -y flathub org.libretro.RetroArch",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y retroarch"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.libretro.RetroArch"
+                        }
+                    },
                     "description": "Enables you to run classic games on a wide range of computers and consoles"
                 },
                 "install_dolphin": {

--- a/nattd.json
+++ b/nattd.json
@@ -596,7 +596,15 @@
                 },
                 "install_obs": {
                     "name": "OBS Studio",
-                    "command": "flatpak install -y flathub com.obsproject.Studio",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y obs-studio",
+                            "dependencies": ["enable_rpmfusion"]
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub com.obsproject.Studio"
+                        }
+                    },
                     "description": "Free and open source software for video capturing, recording, and live streaming."
                 },
                 "install_kdenlive": {

--- a/nattd.json
+++ b/nattd.json
@@ -300,7 +300,15 @@
                 },
                 "install_discord": {
                     "name": "Discord",
-                    "command": "flatpak install -y flathub com.discordapp.Discord",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y discord",
+                            "dependencies": ["enable_rpmfusion"]
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub com.discordapp.Discord"
+                        }
+                    },
                     "description": "A popular communication platform for gamers and communities"
                 },
                 "install_element": {

--- a/nattd.json
+++ b/nattd.json
@@ -714,8 +714,15 @@
             "apps": {
                 "install_remmina": {
                     "name": "Remmina",
-                    "command": "flatpak install -y flathub org.remmina.Remmina",
-                "description": "A remote-desktop client written in GTK, to use other desktops remotely, from a tiny screen or large monitors"
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y remmina"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.remmina.Remmina"
+                        }
+                    },
+                    "description": "A remote-desktop client written in GTK, to use other desktops remotely, from a tiny screen or large monitors"
                 },
                 "install_nomachine": {
                     "name": "NoMachine",

--- a/nattd.json
+++ b/nattd.json
@@ -391,7 +391,14 @@
                 },
                 "install_dialect": {
                     "name": "Dialect",
-                    "command": "flatpak install -y flathub app.drey.Dialect",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y dialect"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub app.drey.Dialect"
+                        }
+                    },
                     "description": "A translation app for GNOME supporting multiple services"
                 },
                 "install_decoder": {

--- a/nattd.json
+++ b/nattd.json
@@ -641,7 +641,8 @@
                     "description": "A software distribution service with an online store, automated installation, automatic updates, achievements, SteamCloud synchronized savegame and screenshot functionality, and many social features",
                     "installation_types": {
                         "DNF": {
-                            "command": "dnf install -y steam"
+                            "command": "dnf install -y steam",
+                            "dependencies": ["enable_rpmfusion"]
                         },
                         "Flatpak": {
                             "command": "flatpak install -y flathub com.valvesoftware.Steam"

--- a/nattd.json
+++ b/nattd.json
@@ -591,7 +591,14 @@
                 },
                 "install_blender": {
                     "name": "Blender",
-                    "command": "flatpak install -y flathub org.blender.Blender",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y blender"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.blender.Blender"
+                        }
+                    },
                     "description": "A free and open source 3D creation suite."
                 },
                 "install_obs": {

--- a/nattd.json
+++ b/nattd.json
@@ -609,7 +609,14 @@
                 },
                 "install_kdenlive": {
                     "name": "Kdenlive",
-                    "command": "flatpak install -y flathub org.kde.kdenlive",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y kdenlive"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.kde.kdenlive"
+                        }
+                    },
                     "description": "A video editing application with support for many audio and video formats"
                 },
                 "install_freetube": {

--- a/nattd.json
+++ b/nattd.json
@@ -650,7 +650,14 @@
                 },
                 "install_lutris": {
                     "name": "Lutris",
-                    "command": "flatpak install -y flathub net.lutris.Lutris",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y lutris"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub net.lutris.Lutris"
+                        }
+                    },
                     "description": "Helps you install and play video games from all eras and from most gaming systems"
                 },
                 "install_heroic": {

--- a/nattd.json
+++ b/nattd.json
@@ -532,7 +532,14 @@
             "apps": {
                 "install_vlc": {
                     "name": "VLC",
-                    "command": "flatpak install -y flathub org.videolan.VLC",
+                    "installation_types": {
+                        "DNF": {
+                            "command": "dnf install -y vlc"
+                        },
+                        "Flatpak": {
+                            "command": "flatpak install -y flathub org.videolan.VLC"
+                        }
+                    },
                     "description": "A media player with a focus on privacy and security"
                 },
                 "install_stremio": {


### PR DESCRIPTION
### **Used the new function discussed in #15 to add DNF relying on RPM-Fusion options and more.**

**Added the following programs to be installable via DNF:**
- Discord (via RPM-Fusion)
- Dialect
- VLC
- Krita
- Blender
- OBS (via RPM-Fusion)
- Kdenlive
- Lutris
- Retroarch
- Remmina


**Added the RPM Fusion dependency to:**
- Steam

The changes have been tested on an new Fedora 41 VM.