### PR TITLE
Add suboptions for dnf configuration

### DIFF
--- a/nattd.json
+++ b/nattd.json
@@ -14,9 +14,25 @@
             "command": [
                 "color_echo \"yellow\" \"Configuring DNF Package Manager...\"",
                 "backup_file \"/etc/dnf/dnf.conf\"",
-                "echo \"max_parallel_downloads=10\" | tee -a /etc/dnf/dnf.conf > /dev/null",
                 "dnf -y install dnf-plugins-core"
             ],
+            "suboptions": {
+                "max_parallel_downloads": {
+                    "name": "Max Parallel Downloads",
+                    "description": "Set maximum parallel downloads to 10 for faster downloads",
+                    "command": "echo \"max_parallel_downloads=10\" | tee -a /etc/dnf/dnf.conf > /dev/null"
+                },
+                "fastest_mirror": {
+                    "name": "Select Fastest Mirror",
+                    "description": "Selects the fastest download server",
+                    "command": "echo \"fastestmirror=True\" | tee -a /etc/dnf/dnf.conf > /dev/null"
+                },
+                "default_yes": {
+                    "name": "Default Yes",
+                    "description": "Defaults prompts to yes, which is how most other package managers behave",
+                    "command": "echo \"defaultyes=True\" | tee -a /etc/dnf/dnf.conf > /dev/null"
+                }
+            },
             "description": "Optimize DNF package manager for faster downloads and efficient updates"
         },
         "enable_dnf_autoupdate": {
@@ -183,7 +199,7 @@
                     "description": "An open-source browser project that aims to build a safer, faster, and more stable way to experience the web.",
                     "installation_types": {
                         "DNF": {
-                            "command": "dnf install -y chromium"                            
+                            "command": "dnf install -y chromium"
                         },
                         "Flatpak": {
                             "command": "flatpak install -y flathub org.chromium.Chromium"
@@ -282,7 +298,7 @@
                         "Flatpak": {
                             "command": "flatpak install -y flathub org.mozilla.Thunderbird"
                         }
-                    }    
+                    }
                 },
                 "install_betterbird": {
                     "name": "Betterbird",
@@ -917,7 +933,7 @@
                 }
             }
         }
-    },    
+    },
     "customization": {
         "name": "Customization",
         "apps": {

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -167,6 +167,23 @@ def render_sidebar() -> None:
                         hostname = st.text_input("Enter the new hostname:", value=app_state.hostname or "")
                         options["hostname"] = hostname
                         app_state.hostname = hostname
+
+                    if option == "configure_dnf" and options["system_config"][option]:
+                        dnf_data = nattd_data["system_config"][option]
+                        if "suboptions" in dnf_data:
+                            _, indent = st.columns([0.05, 0.95])
+
+                            with indent:
+                                st.caption("Select Optimizations:")
+                                selections = {}
+                                for sub_key, sub_val in dnf_data["suboptions"].items():
+                                    selections[sub_key] = st.checkbox(
+                                        sub_val["name"],
+                                        value=True,
+                                        key=f"dnf_{sub_key}",
+                                        help=sub_val.get("description")
+                                    )
+                                options["system_config"]["configure_dnf_suboptions"] = selections
             except Exception as e:
                 st.sidebar.error(f"Error rendering option '{option}': {str(e)}")
                 logging.error(f"Error rendering option '{option}': {str(e)}", exc_info=True)


### PR DESCRIPTION
This should close #28 and also add the `defaultyes=True` option that I was wanting from this script. Just makes it a little more granular and choice seems like a good thing

<img width="334" height="247" alt="image" src="https://github.com/user-attachments/assets/e2fdc458-1539-4c54-84af-5ed08c40cf54" />

The above selection creates this snippet:

```sh
color_echo "yellow" "Configuring DNF Package Manager..."
backup_file "/etc/dnf/dnf.conf"
dnf -y install dnf-plugins-core
# Max Parallel Downloads
echo "max_parallel_downloads=10" | tee -a /etc/dnf/dnf.conf > /dev/null
# Select Fastest Mirror
echo "fastestmirror=True" | tee -a /etc/dnf/dnf.conf > /dev/null
# Default Yes
echo "defaultyes=True" | tee -a /etc/dnf/dnf.conf > /dev/null
```